### PR TITLE
Show player names in DomSession

### DIFF
--- a/features/support/World.js
+++ b/features/support/World.js
@@ -42,8 +42,11 @@ class World {
 
     const sessionFactories = {
       DomSession: async controller => {
+        const playerElement = document.createElement('div')
+        playerElement.innerHTML = `<div>${playerName}</div>`
+        document.body.appendChild(playerElement)
         const rootElement = document.createElement('div')
-        document.body.appendChild(rootElement)
+        playerElement.appendChild(rootElement)
         const domApp = new DomApp({rootElement, controller})
         domApp.showIndex()
         return new DomSession({rootElement})


### PR DESCRIPTION
Adds player names to each DomSession root element, which makes it easier to understand what's going on in interactive mode:

<img width="224" alt="screen shot 2018-05-22 at 06 35 23" src="https://user-images.githubusercontent.com/22017/40343964-6f55ebfa-5d8a-11e8-9ab6-911703c00158.png">
