### PR TITLE
Games have 5 letters, not 5 characters

### DIFF
--- a/features/guess_the_word.feature
+++ b/features/guess_the_word.feature
@@ -9,7 +9,7 @@ Feature: Guess the word
   Scenario: Breaker joins a game
     Given the Maker has started a game with the word "silky"
     When the Breaker joins the Maker's game
-    Then the Breaker must guess a word with 5 characters
+    Then the Breaker must guess a word with 5 letters
 
   # Turn based
 
@@ -38,4 +38,3 @@ Feature: Guess the word
     And the Breaker has guessed "steak"
     When the Maker scores the guess as correct
     Then the Breaker sees that the game is over
-    

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -52,7 +52,7 @@ Then('{player} waits for a Breaker to join', function (maker) {
   assert.equal(gameState, "Waiting for breaker");
 })
 
-Then('{player} must guess a word with {int} characters', function (breaker, wordLength) {
+Then('{player} must guess a word with {int} letters', function (breaker, wordLength) {
   assert.equal(breaker.getWordLength(), wordLength);
 })
 

--- a/lib/dom/DomApp.js
+++ b/lib/dom/DomApp.js
@@ -43,7 +43,7 @@ module.exports = class DomApp {
     const render = ({data}) => {
       this._rootElement.innerHTML = `
         <div itemscope>
-          <h2><span itemscope itemprop="wordLength" itemtype="http://schema.org/Integer">${data.wordLength}</span> character game</h2>
+          <h2><span itemscope itemprop="wordLength" itemtype="http://schema.org/Integer">${data.wordLength}</span> letter game</h2>
           ${data.errorMessage ? `<div itemscope itemprop="errorMessage" itemtype="http://schema.org/Text">${data.errorMessage}</div>` : ''}
           <div itemscope itemprop="gameState" itemtype="http://schema.org/Text">${data.gameState}</div>
           <table itemscope itemprop="guessList" itemtype="http://schema.org/ItemList">
@@ -72,9 +72,9 @@ module.exports = class DomApp {
             ${data.guessList.map(guess => `
               <tr itemscope>
                 <td itemprop="guess" itemtype="http://schema.org/Text">${guess.guess}</td>
-                ${guess.points ? 
+                ${guess.points ?
                   `<td itemprop="points" itemtype="http://schema.org/Integer">${guess.points}</td>`
-                : 
+                :
                   `<td>
                     <div class="row">
                       <form data-command="score" method="POST" >


### PR DESCRIPTION
Changes "5 character game" to "5 letter game".

Words aren't allowed to have numbers or punctuation. I know these rules aren't implemented yet, but we also have a conflicting definition of _character_ in our scenarios.